### PR TITLE
 fix(tag-tree): Fix removal of parent nodes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,7 @@
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			],
-			"preLaunchTask": "npm: watch"
+			"preLaunchTask": "watch"
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,6 +15,11 @@
 				"kind": "build",
 				"isDefault": true
 			}
+		},
+		{
+			"type": "npm",
+			"script": "build:watch",
+			"problemMatcher": []
 		}
 	]
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch --passWithNoTests",
     "vscode:prepublish": "npm run build",
-    "watch": "tsc -watch -p ./"
+    "watch": "npm run build:watch"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^3.0.2",

--- a/src/tag-tree-data-provider.ts
+++ b/src/tag-tree-data-provider.ts
@@ -13,6 +13,7 @@ interface IFileInfo {
 
 class TagTreeDataProvider
   implements vscode.TreeDataProvider<TagNode | FileNode> {
+
   private tagTree: TagTree;
   // Responsible for notifying the TreeDataProvider to update for the specified element in tagTree
   private _onDidChangeTreeData: vscode.EventEmitter< TagNode | FileNode | null> = new vscode.EventEmitter<TagNode | FileNode | null>();

--- a/src/tag-tree/__snapshots__/tag-tree.test.ts.snap
+++ b/src/tag-tree/__snapshots__/tag-tree.test.ts.snap
@@ -395,15 +395,7 @@ exports[`TagTree deleteFile Delete file under shared tag with empty node 1`] = `
                tags: [ 'hello' ] } },
           pathToNode: 'hello',
           tag: 'hello',
-          tags:
-           Map {
-             'world' => TagNode {
-               parent: [Circular],
-               displayName: 'world',
-               files: Map {},
-               pathToNode: 'hello/world',
-               tag: 'world',
-               tags: Map {} } } } } },
+          tags: Map {} } } },
   fileIndex:
    Map {
      '|Users|test|bar.md' => [ TagNode {
@@ -426,15 +418,7 @@ exports[`TagTree deleteFile Delete file under shared tag with empty node 1`] = `
               tags: [ 'hello' ] } },
          pathToNode: 'hello',
          tag: 'hello',
-         tags:
-          Map {
-            'world' => TagNode {
-              parent: [Circular],
-              displayName: 'world',
-              files: Map {},
-              pathToNode: 'hello/world',
-              tag: 'world',
-              tags: Map {} } } } ] } }"
+         tags: Map {} } ] } }"
 `;
 
 exports[`TagTree deleteFile Delete node under root 1`] = `

--- a/src/tag-tree/tag-tree.test.ts
+++ b/src/tag-tree/tag-tree.test.ts
@@ -29,6 +29,19 @@ describe("TagTree", () => {
       tagTree.deleteFile(filePath);
       expect(createDeepSnapshot(tagTree)).toMatchSnapshot();
     });
+
+    test("Move tag tree from one top level node to another", () => {
+      const tagTree = new TagTree();
+      const filePath = "/Users/test/foo.md";
+      tagTree.addFile(filePath, ["hello/world"], "foo.md");
+      tagTree.deleteFile(filePath);
+      tagTree.addFile(filePath, ["goodbye/world"], "foo.md");
+      const tag = tagTree.root.getTag("hello");
+      const renamedTag = tagTree.root.getTag("goodbye");
+
+      expect(tag).toBeUndefined();
+      expect(renamedTag).toBeDefined();
+    });
   });
   describe("getTagsForFile", () => {
     test("Retrieves all tags for a file", () => {

--- a/src/tag-tree/tag-tree.ts
+++ b/src/tag-tree/tag-tree.ts
@@ -114,10 +114,12 @@ class TagTree {
 
     while (currentNode!.files.size === 0 && currentNode!.tags.size === 0) {
       const { parent } = currentNode;
+      // We're not at the root of the tree yet
       if (parent !== null) {
-        parent!.deleteTag(node.tag);
+        parent!.deleteTag(currentNode.tag);
         // @ts-ignore
         currentNode = parent;
+      // At this point we've hit the root of the tree
       } else {
         break;
       }


### PR DESCRIPTION
When renaming a tag with hierarchy, if the root node was renamed, when
removing the path to the node, parents would not be properly cleaned up.

Closes #37