### PR TITLE
Dustinsterk feat(tagtree) go to tag references

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,27 @@ import { TagTreeView } from "./tag-tree-view";
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
+  //Custom Comment to Jump to Line
+  vscode.commands.registerCommand('extension.jumpToLine', mySelectedNode => {
+    //Open the file and select the proper tag line
+    vscode.commands.executeCommand('vscode.open', vscode.Uri.file(mySelectedNode.filePath));
+
+    //Jump to Tag and focus the lines in screen
+    var editor = vscode.window.activeTextEditor;
+    if (editor != undefined) {
+        var endInt = mySelectedNode.pathToNode.indexOf(')',0);
+        if (endInt > 0) { //Check for LineNum for the new tag objects
+          var lineno = parseInt(mySelectedNode.pathToNode.split("/LineNum(")[1].substring(0, endInt)) - 1;
+          var selectLine: vscode.Selection = new vscode.Selection(lineno,0,lineno,0);
+          var tagSelections: vscode.Selection[] = [selectLine];
+          editor.selections = tagSelections;
+          vscode.commands.executeCommand('revealLine', {lineNumber: lineno, at: 'middle'});
+        }
+    }
+    else {
+      vscode.window.showInformationMessage('Undefined editor window');
+    }
+  });
   new TagTreeView(context);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,29 +6,34 @@ import { TagTreeView } from "./tag-tree-view";
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-  //Custom Comment to Jump to Line
+  //Custom command to open a file and jump to a line and focus the editor
   vscode.commands.registerCommand('extension.jumpToLine', mySelectedNode => {
     //Open the file and select the proper tag line
-    vscode.commands.executeCommand('vscode.open', vscode.Uri.file(mySelectedNode.filePath));
-
-    //Jump to Tag and focus the lines in screen
-    var editor = vscode.window.activeTextEditor;
-    if (editor != undefined) {
-        var endInt = mySelectedNode.pathToNode.indexOf(')',0);
-        if (endInt > 0) { //Check for LineNum for the new tag objects
-          var lineno = parseInt(mySelectedNode.pathToNode.split("/LineNum(")[1].substring(0, endInt)) - 1;
-          var selectLine: vscode.Selection = new vscode.Selection(lineno,0,lineno,0);
-          var tagSelections: vscode.Selection[] = [selectLine];
-          editor.selections = tagSelections;
-          vscode.commands.executeCommand('revealLine', {lineNumber: lineno, at: 'middle'});
+    vscode.commands.executeCommand('vscode.open', vscode.Uri.file(mySelectedNode.filePath)).then(function () {
+      setTimeout(function () {
+        //Jump to Tag and focus the lines in screen
+        var editor = vscode.window.activeTextEditor;
+        if (editor != undefined) {
+          //parse the line number from the tree 'LineNum(X)' text
+          var endInt = mySelectedNode.pathToNode.indexOf(')', 0);
+          if (endInt > 0) { //Check for LineNum for the new tag objects
+            var lineno = parseInt(mySelectedNode.pathToNode.split("/LineNum(")[1].substring(0, endInt)) - 1;
+            var selectLine: vscode.Selection = new vscode.Selection(lineno, 0, lineno, 0);
+            var tagSelections: vscode.Selection[] = [selectLine];
+            if (editor.document.uri.path.length > 0) {
+              editor.selections = tagSelections;
+              vscode.commands.executeCommand('revealLine', { lineNumber: lineno, at: 'middle' });
+            }
+          }
         }
-    }
-    else {
-      vscode.window.showInformationMessage('Undefined editor window');
-    }
+        else {
+          vscode.window.showInformationMessage('Undefined editor window.');
+        }
+      }, 300);
+    });
   });
   new TagTreeView(context);
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }

--- a/src/tag-tree-data-provider.ts
+++ b/src/tag-tree-data-provider.ts
@@ -265,7 +265,7 @@ class TagTreeDataProvider
   var itemToProcess;
   var newTreeElementString;
 
-  var filename = filePath.replace(/^.*[\\\/]/, '').split('.').slice(0, -1).join('.');
+  //var filename = filePath.replace(/^.*[\\\/]/, '').split('.').slice(0, -1).join('.');
    
   // Parse any yaml frontmatter and check for tags within that frontmatter
   const { data } = grayMatter(fileContents);
@@ -298,7 +298,7 @@ class TagTreeDataProvider
       itemToProcess = f[0].replace('@nested-tags:','').replace("<!--", "").replace("-->", "").replace("*/", "").replace("/*", "").split(",");
       itemToProcess.forEach(itm=>{
         newTreeElementString = "";
-        newTreeElementString = itm + "/[" + filename +"]/LineNum(" + lines.toString() + ")";    
+        newTreeElementString = itm +"/LineNum(" + lines.toString() + ")";    
         allTags.push(newTreeElementString);
       });
     }
@@ -316,7 +316,7 @@ class TagTreeDataProvider
     for (let f, reg = /\B@@[A-Za-z0-9\-\.\_\/]+\b/g; f = reg.exec(fileContents.substring(i, j));) {
       itemToProcess = f[0];//.replace('@nested-tags:','');
       newTreeElementString = "";
-      newTreeElementString = itemToProcess + "/[" + filename + "]/LineNum(" + lines.toString() + ")";    
+      newTreeElementString = itemToProcess + "/LineNum(" + lines.toString() + ")";    
       allTags.push(newTreeElementString);
     }
     lines++;

--- a/src/tag-tree-data-provider.ts
+++ b/src/tag-tree-data-provider.ts
@@ -310,10 +310,10 @@ class TagTreeDataProvider
     j = 0;
     lines = 1;
 
-    //Special '@@' tags
+    //Special '~~' tags
     //Loop on '/n' and process each line with a regex looking for '@@' tags
     while ((j = fileContents.indexOf(char, i)) !== -1) {
-      for (let f, reg = /\B@@[A-Za-z0-9\-\.\_\/]+\b/g; f = reg.exec(fileContents.substring(i, j));) {
+      for (let f, reg = /\B~~[A-Za-z0-9\-\.\_\/]+\b/g; f = reg.exec(fileContents.substring(i, j));) {
         itemToProcess = f[0];//.replace('@nested-tags:','');
         newTreeElementString = "";
         newTreeElementString = itemToProcess + "/LineNum(" + lines.toString() + ")";

--- a/src/tag-tree-data-provider.ts
+++ b/src/tag-tree-data-provider.ts
@@ -75,7 +75,7 @@ class TagTreeDataProvider
           this.tagTree.addFile(info.filePath, [...info.tags], displayName);
         });
 
-        this._onDidChangeTreeData.fire();
+      this._onDidChangeTreeData.fire();
     })();
   }
 
@@ -210,7 +210,7 @@ class TagTreeDataProvider
       this.tagTree.addFile(
         fileUri.fsPath,
         [...fileInfo.tags.values()],
-        displayName 
+        displayName
       );
       this._onDidChangeTreeData.fire();
     }
@@ -257,72 +257,72 @@ class TagTreeDataProvider
     fileContents: string,
     filePath: string
   ): IFileInfo {
-  var allTags = new Array();
-  var char = '\n';
-  var i = 0;
-  var j = 0;
-  var lines = 1;
-  var itemToProcess;
-  var newTreeElementString;
+    var allTags = new Array();
+    var char = '\n';
+    var i = 0;
+    var j = 0;
+    var lines = 1;
+    var itemToProcess;
+    var newTreeElementString;
 
-  //var filename = filePath.replace(/^.*[\\\/]/, '').split('.').slice(0, -1).join('.');
-   
-  // Parse any yaml frontmatter and check for tags within that frontmatter
-  const { data } = grayMatter(fileContents);
-  if (data.tags) {
-    //find the 'tags:' linenumber
-    /*
-    var searchStr = fileContents.split('\n');
-    var foundline = 0;
-    searchStr.forEach((line, number) => {
-        if (line.includes("tags:")){
-          foundline = lines;
-        }
-        else
-          lines++;
-    });*/
-    //load the tags from the grayMatter YAML parser
-    data.tags.forEach((tag: any)=> {
-      allTags.push(tag); // + "/LineNum(" + foundline.toString() + ")");
-    });
-  }
+    //var filename = filePath.replace(/^.*[\\\/]/, '').split('.').slice(0, -1).join('.');
 
-  i = 0;
-  j = 0;
-  lines = 1;
-
-  //Inline Tags
-  //Loop on '/n' and process each line with a regex looking for nested tags
-  while ((j = fileContents.indexOf(char, i)) !== -1) {
-    for (let f, reg = /\B.+@(nested-tags:).+/g; f = reg.exec(fileContents.substring(i, j));) {
-      itemToProcess = f[0].replace('@nested-tags:','').replace("<!--", "").replace("-->", "").replace("*/", "").replace("/*", "").split(",");
-      itemToProcess.forEach(itm=>{
-        newTreeElementString = "";
-        newTreeElementString = itm +"/LineNum(" + lines.toString() + ")";    
-        allTags.push(newTreeElementString);
+    // Parse any yaml frontmatter and check for tags within that frontmatter
+    const { data } = grayMatter(fileContents);
+    if (data.tags) {
+      //find the 'tags:' linenumber
+      /*
+      var searchStr = fileContents.split('\n');
+      var foundline = 0;
+      searchStr.forEach((line, number) => {
+          if (line.includes("tags:")){
+            foundline = lines;
+          }
+          else
+            lines++;
+      });*/
+      //load the tags from the grayMatter YAML parser
+      data.tags.forEach((tag: any) => {
+        allTags.push(tag); // + "/LineNum(" + foundline.toString() + ")");
       });
     }
-    lines++;
-    i = j + 1;
-  }
 
-  i = 0;
-  j = 0;
-  lines = 1;
+    i = 0;
+    j = 0;
+    lines = 1;
 
-  //Special '@@' tags
-  //Loop on '/n' and process each line with a regex looking for '@@' tags
-  while ((j = fileContents.indexOf(char, i)) !== -1) {
-    for (let f, reg = /\B@@[A-Za-z0-9\-\.\_\/]+\b/g; f = reg.exec(fileContents.substring(i, j));) {
-      itemToProcess = f[0];//.replace('@nested-tags:','');
-      newTreeElementString = "";
-      newTreeElementString = itemToProcess + "/LineNum(" + lines.toString() + ")";    
-      allTags.push(newTreeElementString);
+    //Inline Tags
+    //Loop on '/n' and process each line with a regex looking for nested tags
+    while ((j = fileContents.indexOf(char, i)) !== -1) {
+      for (let f, reg = /\B.+@(nested-tags:).+/g; f = reg.exec(fileContents.substring(i, j));) {
+        itemToProcess = f[0].replace('@nested-tags:', '').replace("<!--", "").replace("-->", "").replace("*/", "").replace("/*", "").split(",");
+        itemToProcess.forEach(itm => {
+          newTreeElementString = "";
+          newTreeElementString = itm + "/LineNum(" + lines.toString() + ")";
+          allTags.push(newTreeElementString);
+        });
+      }
+      lines++;
+      i = j + 1;
     }
-    lines++;
-    i = j + 1;
-  }
-  return {tags: new Set(allTags), filePath: filePath};
+
+    i = 0;
+    j = 0;
+    lines = 1;
+
+    //Special '@@' tags
+    //Loop on '/n' and process each line with a regex looking for '@@' tags
+    while ((j = fileContents.indexOf(char, i)) !== -1) {
+      for (let f, reg = /\B@@[A-Za-z0-9\-\.\_\/]+\b/g; f = reg.exec(fileContents.substring(i, j));) {
+        itemToProcess = f[0];//.replace('@nested-tags:','');
+        newTreeElementString = "";
+        newTreeElementString = itemToProcess + "/LineNum(" + lines.toString() + ")";
+        allTags.push(newTreeElementString);
+      }
+      lines++;
+      i = j + 1;
+    }
+    return { tags: new Set(allTags), filePath: filePath };
   }
 
   /**


### PR DESCRIPTION
I have created this proof of concept that allows you to add "~~" tags anywhere in the markdown (due to the ASCII ascending order, they will fall at the bottom of the tag list -- which I personally like).  I have also changed the tree structure to show LineNum(X) in the hierarchy a step above the filename.    If a LineNum(X) is found, the click action on the filename will both open the file and jump to the line and center the editor/focus correctly on the line number.  If a LineNum is not found (I excluded them with YAML tags for instance), it will just open the file.